### PR TITLE
Run migrations on server startup in docker

### DIFF
--- a/api/docker/server.sh
+++ b/api/docker/server.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -eux
 python /app/api/manage.py collectstatic --noinput
+python /app/api/manage.py migrate
 cd /app/api/
 gunicorn --log-file=- --worker-tmp-dir /dev/shm config.asgi:application -w ${STOCKAZIO_WEB_WORKERS-2} --threads ${STOCKAZIO_WEB_THREADS-4} -k uvicorn.workers.UvicornWorker -b 0.0.0.0:8000 ${GUNICORN_ARGS-}


### PR DESCRIPTION
Takes care of forgetting to run migrations - if they're already up to date it's a no-op.